### PR TITLE
Blind sign

### DIFF
--- a/src/ccs08.rs
+++ b/src/ccs08.rs
@@ -113,7 +113,7 @@ prove_ul method is used to produce the ZKRP proof that secret x belongs to the i
         let m = E::Fr::rand(rng);
 
         // D = H^m
-        let mut hm = self.com.h.clone();
+        let mut hm = self.com.h2.clone();
         hm.mul_assign(m);
         for i in 0..self.l as usize {
             v.push(E::Fr::rand(rng));
@@ -143,7 +143,7 @@ prove_ul method is used to produce the ZKRP proof that secret x belongs to the i
             let ui = self.u.pow(i as u32);
             let mut muiti = t[i].clone();
             muiti.mul_assign(&E::Fr::from_str(&ui.to_string()).unwrap());
-            let mut aux = self.com.g.clone();
+            let mut aux = self.com.g2.clone();
             aux.mul_assign(muiti);
             D.add_assign(&aux);
         }
@@ -206,17 +206,17 @@ verify_ul is used to validate the ZKRP proof. It returns true iff the proof is v
     }
 
     fn verify_part1(&self, proof: &ProofUL<E>) -> bool {
-        let mut D = proof.comm.c.clone();
+        let mut D = proof.comm.c2.clone();
         D.mul_assign(proof.ch);
         D.negate();
-        let mut hzr = self.com.h.clone();
+        let mut hzr = self.com.h2.clone();
         hzr.mul_assign(proof.zr);
         D.add_assign(&hzr);
         for i in 0..self.l {
             let ui = self.u.pow(i as u32);
             let mut muizsigi = proof.zsig[i as usize];
             muizsigi.mul_assign(&E::Fr::from_str(&ui.to_string()).unwrap());
-            let mut aux = self.com.g.clone();
+            let mut aux = self.com.g2.clone();
             aux.mul_assign(muizsigi);
             D.add_assign(&aux);
         }

--- a/src/ped92.rs
+++ b/src/ped92.rs
@@ -5,18 +5,22 @@ use ff::Rand;
 
 #[derive(Clone)]
 pub struct CSParams<E: Engine> {
-    pub g: E::G2,
-    pub h: E::G2,
+    pub g1: E::G1,
+    pub g2: E::G2,
+    pub h1: E::G1,
+    pub h2: E::G2,
 }
 
 #[derive(Clone)]
 pub struct Commitment<E: Engine> {
-    pub c: E::G2
+    pub c1: E::G1,
+    pub c2: E::G2
 }
 
 #[derive(Clone)]
 pub struct CSMultiParams<E: Engine> {
-    pub pub_bases: Vec<E::G2>
+    pub pub_bases1: Vec<E::G1>,
+    pub pub_bases2: Vec<E::G2>
 }
 
 //impl<E: Engine> fmt::Display for CSParams<E> {
@@ -59,9 +63,11 @@ impl<E: Engine> CSParams<E> {
 Implements the setup algorithm for the Pedersen92 commitment scheme
 */
     pub fn setup<R: Rng>(rng: &mut R) -> Self {
-        let g = E::G2::rand(rng);
-        let h = E::G2::rand(rng);
-        let csp = CSParams { g, h };
+        let g1 = E::G1::rand(rng);
+        let g2 = E::G2::rand(rng);
+        let h1 = E::G1::rand(rng);
+        let h2 = E::G2::rand(rng);
+        let csp = CSParams { g1, g2, h1, h2 };
         return csp;
     }
 
@@ -74,15 +80,21 @@ commit(pk, msg) -> cm where
     pub fn commit<R: Rng>(&self, rng: &mut R, m: E::Fr, R: Option<E::Fr>) -> Commitment<E> {
         let r = R.unwrap_or(E::Fr::rand(rng));
 
-        let p = "commit -> m";
         // c = g^m * h^r
-        let mut c = self.g.clone();
-        c.mul_assign(m);
-        let mut h = self.h.clone();
-        h.mul_assign(r);
-        c.add_assign(&h);
+        let mut c1 = self.g1.clone();
+        c1.mul_assign(m.clone());
+        let mut h1 = self.h1.clone();
+        h1.mul_assign(r.clone());
+        c1.add_assign(&h1);
 
-        Commitment { c }
+        // c = g^m * h^r
+        let mut c2 = self.g2.clone();
+        c2.mul_assign(m);
+        let mut h2 = self.h2.clone();
+        h2.mul_assign(r);
+        c2.add_assign(&h2);
+
+        Commitment { c1, c2 }
     }
 
     /*
@@ -92,14 +104,18 @@ decommit(csp, cm, msg) -> bool where
 - outputs T/F for whether the cm is a valid commitment to the msg
 */
     pub fn decommit(&self, cm: &Commitment<E>, m: &E::Fr, r: &E::Fr) -> bool {
-        let p = "decommit -> m";
+        let mut dm1 = self.g1.clone();
+        dm1.mul_assign(m.clone());
+        let mut h1 = self.h1.clone();
+        h1.mul_assign(r.clone());
+        dm1.add_assign(&h1);
 
-        let mut dm = self.g.clone();
-        dm.mul_assign(m.clone());
-        let mut h = self.h.clone();
-        h.mul_assign(r.clone());
-        dm.add_assign(&h);
-        return dm == cm.c;
+        let mut dm2 = self.g2.clone();
+        dm2.mul_assign(m.clone());
+        let mut h2 = self.h2.clone();
+        h2.mul_assign(r.clone());
+        dm2.add_assign(&h2);
+        return dm2 == cm.c2 && dm1 == cm.c1;
     }
 }
 
@@ -110,40 +126,51 @@ impl<E: Engine> CSMultiParams<E> {
     a vector of messages.
     */
     pub fn setup_gen_params<R: Rng>(rng: &mut R, len: usize) -> Self {
-        let mut p: Vec<E::G2> = Vec::new();
+        let mut p1: Vec<E::G1> = Vec::new();
+        let mut p2: Vec<E::G2> = Vec::new();
         for i in 0..len {
-            p.push(E::G2::rand(rng));
+            p1.push(E::G1::rand(rng));
+            p2.push(E::G2::rand(rng));
         }
-        return CSMultiParams { pub_bases: p };
+        return CSMultiParams { pub_bases1: p1, pub_bases2: p2 };
     }
 
     pub fn commit<R: Rng>(&self, rng: &mut R, x: &Vec<E::Fr>, r: &E::Fr) -> Commitment<E> {
         //let r = R.unwrap_or(Fr::random(rng));
         // c = g1^m1 * ... * gn^mn * h^r
-        let mut c = self.pub_bases[0].clone();
-        c.mul_assign(r.clone());
+        let mut c1 = self.pub_bases1[0].clone();
+        let mut c2 = self.pub_bases2[0].clone();
+        c1.mul_assign(r.clone());
+        c2.mul_assign(r.clone());
         for i in 1..x.len() {
-            let mut basis = self.pub_bases[i];
-            basis.mul_assign(x[i]);
-            c.add_assign(&basis);
+            let mut basis1 = self.pub_bases1[i];
+            basis1.mul_assign(x[i]);
+            c1.add_assign(&basis1);
+            let mut basis2 = self.pub_bases2[i];
+            basis2.mul_assign(x[i]);
+            c2.add_assign(&basis2);
         }
         // return (c, r) <- r
-        Commitment { c: c }
+        Commitment { c1, c2 }
     }
 
     pub fn decommit(&self, cm: &Commitment<E>, x: &Vec<E::Fr>, r: &E::Fr) -> bool {
         let l = x.len();
         // pub_base[0] => h, x[0] => r
         // check that cm.r == x[0]
-        let cr = r.clone();
-        let mut dc = self.pub_bases[0].clone();
-        dc.mul_assign(cr);
+        let mut dc1 = self.pub_bases1[0].clone();
+        let mut dc2 = self.pub_bases2[0].clone();
+        dc1.mul_assign(r.clone());
+        dc2.mul_assign(r.clone());
         for i in 1..l {
-            let mut basis = self.pub_bases[i];
-            basis.mul_assign(x[i]);
-            dc.add_assign(&basis);
+            let mut basis1 = self.pub_bases1[i];
+            basis1.mul_assign(x[i]);
+            dc1.add_assign(&basis1);
+            let mut basis2 = self.pub_bases2[i];
+            basis2.mul_assign(x[i]);
+            dc2.add_assign(&basis2);
         }
-        return dc == cm.c && cr == x[0];
+        return dc2 == cm.c2 && dc1 == cm.c1;
     }
 }
 
@@ -178,7 +205,7 @@ mod tests {
         for i in 0..len {
             m.push(Fr::rand(rng));
         }
-        let r = m[0].clone();
+        let r = Fr::rand(rng);
         let c = csp.commit(rng, &m, &r);
 
         assert_eq!(csp.decommit(&c, &m, &r), true);

--- a/src/ped92.rs
+++ b/src/ped92.rs
@@ -128,7 +128,8 @@ impl<E: Engine> CSMultiParams<E> {
     pub fn setup_gen_params<R: Rng>(rng: &mut R, len: usize) -> Self {
         let mut p1: Vec<E::G1> = Vec::new();
         let mut p2: Vec<E::G2> = Vec::new();
-        for i in 0..len {
+        // 1 extra base element for the random parameter
+        for i in 0..len + 1 {
             p1.push(E::G1::rand(rng));
             p2.push(E::G2::rand(rng));
         }
@@ -142,11 +143,11 @@ impl<E: Engine> CSMultiParams<E> {
         let mut c2 = self.pub_bases2[0].clone();
         c1.mul_assign(r.clone());
         c2.mul_assign(r.clone());
-        for i in 1..x.len() {
-            let mut basis1 = self.pub_bases1[i];
+        for i in 0..x.len() {
+            let mut basis1 = self.pub_bases1[i+1];
             basis1.mul_assign(x[i]);
             c1.add_assign(&basis1);
-            let mut basis2 = self.pub_bases2[i];
+            let mut basis2 = self.pub_bases2[i+1];
             basis2.mul_assign(x[i]);
             c2.add_assign(&basis2);
         }
@@ -162,11 +163,11 @@ impl<E: Engine> CSMultiParams<E> {
         let mut dc2 = self.pub_bases2[0].clone();
         dc1.mul_assign(r.clone());
         dc2.mul_assign(r.clone());
-        for i in 1..l {
-            let mut basis1 = self.pub_bases1[i];
+        for i in 0..l {
+            let mut basis1 = self.pub_bases1[i+1];
             basis1.mul_assign(x[i]);
             dc1.add_assign(&basis1);
-            let mut basis2 = self.pub_bases2[i];
+            let mut basis2 = self.pub_bases2[i+1];
             basis2.mul_assign(x[i]);
             dc2.add_assign(&basis2);
         }


### PR DESCRIPTION
I splitted commitments in two parts such that a commitment contains one in G1 and G2. At some point we should refactor this to use generics, such that one can choose the group in which one wants to commit.

I also completed the method to perform a blind signature, i.e. a signature on a committed value.